### PR TITLE
fix: call ApplicationBase::shutdown() in demo application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.16)
 project(ChimeraTK-ControlSystemAdapter-OPCUAAdapter)
 SET(${PROJECT_NAME}_MAJOR_VERSION 03)
 SET(${PROJECT_NAME}_MINOR_VERSION 02)
-SET(${PROJECT_NAME}_PATCH_VERSION 01)
+SET(${PROJECT_NAME}_PATCH_VERSION 02)
 include(${CMAKE_SOURCE_DIR}/cmake/set_version_numbers.cmake)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)

--- a/examples/csa_opcua_adapter_example2.cpp
+++ b/examples/csa_opcua_adapter_example2.cpp
@@ -32,8 +32,8 @@ extern "C" {
 #include <errno.h>
 #include <stdlib.h>
 
-#include "ChimeraTK/ControlSystemAdapter/DevicePVManager.h"
-#include "ChimeraTK/ControlSystemAdapter/ApplicationBase.h"
+#include <ChimeraTK/ControlSystemAdapter/DevicePVManager.h>
+#include <ChimeraTK/ControlSystemAdapter/ApplicationBase.h>
 
 using namespace std;
 using namespace ChimeraTK;
@@ -45,9 +45,7 @@ struct MyApp : public ApplicationBase {
   void run() { cout << "Application run..." << endl; }
 
   void shutdown() {
-    std::lock_guard<std::mutex> lock(instance_mutex);
-    instance = nullptr;
-    hasBeenShutdown = true;
+    ApplicationBase::shutdown();
     cout << "Application shutdown..." << endl;
   }
 


### PR DESCRIPTION
what:
Call ApplicationBase::shutdown() in the demo application instead of re-implementing it.

why:
The re-implementation was using the internal mutex and the variables protected by it. Renaming one of them broke the code. This is avoided by using the intended interface.