### PR TITLE
chore: update Python bindings helper

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/cmake/Doxyfile.in
+++ b/cmake/Doxyfile.in
@@ -51,7 +51,7 @@ PROJECT_BRIEF          =
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = @CMAKE_CURRENT_SOURCE_DIR@/doc/PLT_Logo.png
+PROJECT_LOGO           = @CMAKE_CURRENT_SOURCE_DIR@/doc/ChimeraTK_Logo_whitebg.png
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is


### PR DESCRIPTION
This file was modified inside the DeviceAccess Python bindings, which
is not allowed for files that are part of project-template. This commit
attempts to rectify this situation. It is unclear though whether this
file should be really part of the project-template.
