### PR TITLE
fix(mapfile-generator): Include PVs with return channel to history.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.16)
 project(ChimeraTK-ControlSystemAdapter-OPCUAAdapter)
 SET(${PROJECT_NAME}_MAJOR_VERSION 04)
 SET(${PROJECT_NAME}_MINOR_VERSION 00)
-SET(${PROJECT_NAME}_PATCH_VERSION 04)
+SET(${PROJECT_NAME}_PATCH_VERSION 05)
 include(${CMAKE_SOURCE_DIR}/cmake/set_version_numbers.cmake)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)

--- a/tools/mapfileGenerator/ctk_opcua_generator_tools/generatorForm.py
+++ b/tools/mapfileGenerator/ctk_opcua_generator_tools/generatorForm.py
@@ -322,7 +322,7 @@ class MapGeneratorForm(QMainWindow, Ui_MainWindow):
       unit = "{} (Orig.: {})".format(v.newUnit, v.unit)
     node = QTreeWidgetItem(parent, [name]+[""]*2 + [unit] + [description]+[v.newDestination])
     
-    if v.direction == 'control_system_to_application':
+    if 'control_system_to_application' in v.direction:
       node.setBackground(0,QBrush(QColor("#fee8c8")))
     else:
       node.setBackground(0,QBrush(QColor("#e5f5e0")))
@@ -565,7 +565,7 @@ class MapGeneratorForm(QMainWindow, Ui_MainWindow):
     
   def addHistoryForInputs(self, isChecked:bool, node:QTreeWidgetItem):
     data = node.data(0, Qt.UserRole)
-    if isinstance(data, XMLVar) and data.direction == 'control_system_to_application':
+    if isinstance(data, XMLVar) and ('control_system_to_application' in data.direction):
       if isChecked:
         self.treeWidget.itemWidget(node, 2).setCurrentText(self.histories.currentText())
       else:


### PR DESCRIPTION
When using the option to assign a history for all input PVs to a history inputs with return channels were not included. This is now fixed.